### PR TITLE
Add three tick teak plugin with setup script

### DIFF
--- a/runelite-plugin.properties
+++ b/runelite-plugin.properties
@@ -3,4 +3,4 @@ author=Nobody
 support=
 description=An example greeter plugin
 tags=
-plugins=com.example.ExamplePlugin
+plugins=com.example.TeakPlugin.ThreeTickTeakPlugin

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Simple setup script for offline test environment
+# This script installs OpenJDK and pre-downloads Gradle dependencies.
+# It assumes network access is available when executed.
+
+set -e
+
+# Install Java if not present
+if ! command -v java >/dev/null 2>&1; then
+  sudo apt-get update
+  sudo apt-get install -y openjdk-11-jdk
+fi
+
+# Pre-download Gradle wrapper distribution and project dependencies
+./gradlew --no-daemon --refresh-dependencies tasks >/dev/null
+
+echo "Setup complete"

--- a/src/main/java/com/example/TeakPlugin/ThreeTickTeakConfig.java
+++ b/src/main/java/com/example/TeakPlugin/ThreeTickTeakConfig.java
@@ -1,0 +1,17 @@
+package com.example.TeakPlugin;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+
+@ConfigGroup("ThreeTickTeak")
+public interface ThreeTickTeakConfig extends Config {
+    @ConfigItem(
+            keyName = "enabled",
+            name = "Enable plugin",
+            description = "Enable three tick teak woodcutting"
+    )
+    default boolean enabled() {
+        return false;
+    }
+}

--- a/src/main/java/com/example/TeakPlugin/ThreeTickTeakPlugin.java
+++ b/src/main/java/com/example/TeakPlugin/ThreeTickTeakPlugin.java
@@ -1,0 +1,87 @@
+package com.example.TeakPlugin;
+
+import com.example.EthanApiPlugin.Collections.Inventory;
+import com.example.EthanApiPlugin.Collections.TileObjects;
+import com.example.InteractionApi.TileObjectInteraction;
+import com.example.Packets.WidgetPackets;
+import com.google.inject.Inject;
+import com.google.inject.Provides;
+import net.runelite.api.Client;
+import net.runelite.api.TileObject;
+import net.runelite.api.events.GameTick;
+import net.runelite.api.widgets.Widget;
+import net.runelite.client.callback.ClientThread;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.eventbus.Subscribe;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+
+import java.util.Optional;
+
+@PluginDescriptor(
+        name = "Three Tick Teak",
+        description = "Automates 3t teak cutting using guam tar and pestle and mortar",
+        enabledByDefault = false,
+        tags = {"woodcutting"}
+)
+public class ThreeTickTeakPlugin extends Plugin {
+    @Inject
+    private Client client;
+
+    @Inject
+    private ClientThread clientThread;
+
+    @Inject
+    private ThreeTickTeakConfig config;
+
+    /**
+     * Keeps track of the current action in the three-tick cycle.
+     * 0 = prepare guam tar
+     * 1 = chop teak
+     * 2 = idle/wait
+     */
+    private int tickCycle = 0;
+
+    @Provides
+    public ThreeTickTeakConfig getConfig(ConfigManager configManager) {
+        return configManager.getConfig(ThreeTickTeakConfig.class);
+    }
+
+    @Subscribe
+    private void onGameTick(GameTick event) {
+        if (!config.enabled()) {
+            return;
+        }
+
+        switch (tickCycle) {
+            case 0:
+                makeTar();
+                break;
+            case 1:
+                chopTree();
+                break;
+            default:
+                // wait one tick to maintain 3t rhythm
+                break;
+        }
+
+        tickCycle = (tickCycle + 1) % 3;
+    }
+
+    private void chopTree() {
+        clientThread.invokeLater(() -> {
+            Optional<TileObject> teak = TileObjects.search().nameContains("Teak").nearestToPlayer();
+            teak.ifPresent(t -> TileObjectInteraction.interact(t, "Chop down"));
+        });
+    }
+
+    private void makeTar() {
+        clientThread.invokeLater(() -> {
+            Optional<Widget> guam = Inventory.search().withName("Guam leaf").first();
+            Optional<Widget> tar = Inventory.search().withName("Swamp tar").first();
+            if (guam.isPresent() && tar.isPresent() && Inventory.search().withName("Pestle and mortar").first().isPresent()) {
+                WidgetPackets.queueWidgetOnWidget(guam.get(), tar.get());
+            }
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- implement ThreeTickTeak plugin and config
- register plugin in `runelite-plugin.properties`
- add a helper `scripts/setup.sh` to install dependencies when network access is available
- refine the three-tick teak cycle logic

## Testing
- `bash scripts/setup.sh` *(fails: Unable to tunnel through proxy)*
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*


------
https://chatgpt.com/codex/tasks/task_e_6846035cfd788324b7a29f57c34420ec